### PR TITLE
Add abstract interfaces for core components

### DIFF
--- a/core/interfaces/evaluator.py
+++ b/core/interfaces/evaluator.py
@@ -1,0 +1,12 @@
+"""Interfaces for evaluating generated responses."""
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+
+class Evaluator(ABC):
+    """Abstract base class for evaluating responses."""
+
+    @abstractmethod
+    def evaluate(self, query: str, response: str, references: Sequence[str]) -> float:
+        """Return a score for ``response`` given ``query`` and reference documents."""

--- a/core/interfaces/indexer.py
+++ b/core/interfaces/indexer.py
@@ -1,0 +1,16 @@
+"""Interfaces for document indexing."""
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Any
+
+
+class Indexer(ABC):
+    """Abstract base class for indexing documents in a knowledge store."""
+
+    @abstractmethod
+    def add(self, documents: Iterable[Any]) -> None:
+        """Add one or multiple documents to the index."""
+
+    @abstractmethod
+    def delete(self, document_ids: Iterable[str]) -> None:
+        """Remove documents identified by the given IDs from the index."""

--- a/core/interfaces/response_generator.py
+++ b/core/interfaces/response_generator.py
@@ -1,0 +1,12 @@
+"""Interfaces for generating answers from retrieved context."""
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+
+class ResponseGenerator(ABC):
+    """Abstract base class for generating responses based on retrieved documents."""
+
+    @abstractmethod
+    def generate(self, query: str, documents: Sequence[str]) -> str:
+        """Generate a response for ``query`` using the given ``documents``."""

--- a/core/interfaces/retriever.py
+++ b/core/interfaces/retriever.py
@@ -1,0 +1,12 @@
+"""Interfaces for retrieving documents relevant to a query."""
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+
+class Retriever(ABC):
+    """Abstract base class for retrieving relevant documents."""
+
+    @abstractmethod
+    def retrieve(self, query: str, top_k: int = 5) -> Sequence[str]:
+        """Return up to ``top_k`` documents relevant to ``query``."""


### PR DESCRIPTION
## Summary
- introduce `Indexer` ABC for adding and removing documents
- add `Retriever` ABC for query-based document lookup
- add `ResponseGenerator` and `Evaluator` ABCs to support generating and assessing answers

## Testing
- `make bootstrap` *(fails: curl: (56) CONNECT tunnel failed, response 403)*
- `make format` *(fails: pyenv version `3.13.5` is not installed; black missing)*
- `make test` *(fails: pyenv version `3.13.5` is not installed; pytest missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cb7bbb8e48329944ec5bfb89e5777