### PR TITLE
Add evaluation script for pipeline

### DIFF
--- a/evaluator/eval.py
+++ b/evaluator/eval.py
@@ -1,0 +1,68 @@
+import argparse
+import json
+import os
+from difflib import SequenceMatcher
+from pathlib import Path
+
+import requests
+
+
+def query_pipeline(prompt: str, url: str) -> str:
+    """Send *prompt* to the pipeline and return the answer."""
+    response = requests.post(url, json={"prompt": prompt}, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("answer", "")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description="Evaluate pipeline responses")
+    default_url = os.environ.get("PIPELINE_URL", "http://localhost:8000/query")
+    parser.add_argument(
+        "--tests",
+        type=Path,
+        default=Path(__file__).with_name("tests.json"),
+        help="Path to tests.json file",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).with_name("results.json"),
+        help="Path to write results.json",
+    )
+    parser.add_argument(
+        "--url",
+        default=default_url,
+        help="Pipeline query URL (env: PIPELINE_URL)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    with args.tests.open("r", encoding="utf-8") as f:
+        tests = json.load(f)
+
+    results = []
+    for case in tests:
+        prompt = case["prompt"]
+        expected = case["expected"]
+        answer = query_pipeline(prompt, args.url)
+        score = SequenceMatcher(None, expected, answer).ratio()
+        results.append(
+            {
+                "prompt": prompt,
+                "expected": expected,
+                "answer": answer,
+                "score": score,
+            }
+        )
+
+    with args.output.open("w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluator/tests.json
+++ b/evaluator/tests.json
@@ -1,0 +1,3 @@
+[
+  {"prompt": "Hello", "expected": "Hello"}
+]


### PR DESCRIPTION
## Summary
- add evaluator/eval.py to run prompts through the pipeline and score answers
- include sample tests.json for evaluation data
- allow evaluator to accept custom test/output paths and pipeline URL via CLI

## Testing
- `python3 -m py_compile evaluator/eval.py && echo 'py_compile succeeded'`
- `pip install --break-system-packages -r requirements.txt --ignore-installed wheel`
- `pre-commit run --files evaluator/eval.py evaluator/tests.json` *(fails: pathspec '6.11.0' did not match any file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cb7be84748329b672b1046701b64f