### PR TITLE
Add Chainlit backend with feedback logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/PyCQA/isort
-    rev: 6.11.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python import sorting)
@@ -15,8 +15,8 @@ repos:
         # synchronisiert mit black style
         args: ["--profile", "black"]
 
-  - repo: https://github.com/charliermarsh/ruff
-    rev: v0.0.297
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.9
     hooks:
       - id: ruff
         args: ["--fix"]  # optional: automatisch beheben, wenn möglich

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,59 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+import chainlit as cl
+
+INDEX_PATH = Path(__file__).parent / "index.json"
+FEEDBACK_PATH = Path(__file__).parent / "feedback.log"
+
+
+def load_index() -> dict:
+    if INDEX_PATH.exists():
+        with INDEX_PATH.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def retrieve(query: str, data: dict) -> str:
+    docs = data.get("documents", [])
+    query_lower = query.lower()
+    for doc in docs:
+        if query_lower in doc.lower():
+            return doc
+    return "Keine passende Antwort gefunden."
+
+
+index = {}
+
+
+@cl.on_chat_start
+async def on_chat_start() -> None:
+    """Load the retrieval index when the chat session starts."""
+    global index
+    index = load_index()
+    await cl.Message(content="Index geladen. Stelle deine Frage!").send()
+
+
+@cl.on_message
+async def on_message(message: cl.Message) -> None:
+    """Handle incoming user messages."""
+    answer = retrieve(message.content, index)
+    sent = cl.Message(content=answer)
+    await sent.send()
+
+    actions = [
+        cl.Action(name="feedback", value="up", label="👍"),
+        cl.Action(name="feedback", value="down", label="👎"),
+    ]
+    result = await cl.AskActionMessage(
+        content="War die Antwort hilfreich?",
+        actions=actions,
+    ).send()
+
+    if result and result.value == "down":
+        detail = await cl.AskUserMessage(content="Bitte beschreibe das Problem.").send()
+        with FEEDBACK_PATH.open("a", encoding="utf-8") as f:
+            f.write(
+                f"{datetime.utcnow().isoformat()}\t{message.content}\t{detail.content}\n"
+            )

--- a/backend/chainlit.toml
+++ b/backend/chainlit.toml
@@ -1,0 +1,2 @@
+[project]
+name = "backend"

--- a/backend/index.json
+++ b/backend/index.json
@@ -1,0 +1,6 @@
+{
+  "documents": [
+    "Chainlit hilft bei der Erstellung von Chat-Apps.",
+    "Dies ist ein Beispiel-Dokument für das Backend."
+  ]
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,1 @@
+chainlit


### PR DESCRIPTION
## Summary
- add minimal Chainlit app that loads an index, retrieves answers, and records negative feedback
- configure Chainlit project and minimal requirements
- provide example index data
- update pre-commit configuration to use current hook revisions

## Testing
- `pre-commit run --files backend/app.py backend/chainlit.toml backend/requirements.txt backend/index.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cb7be2b508329af078cdcb5ce8c75