### PR TITLE
Add document indexer and watcher service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/PyCQA/isort
-    rev: 6.11.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python import sorting)
@@ -15,8 +15,8 @@ repos:
         # synchronisiert mit black style
         args: ["--profile", "black"]
 
-  - repo: https://github.com/charliermarsh/ruff
-    rev: v0.0.297
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.9
     hooks:
       - id: ruff
         args: ["--fix"]  # optional: automatisch beheben, wenn möglich

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "watcher.py"]

--- a/indexer/ingest.py
+++ b/indexer/ingest.py
@@ -1,0 +1,54 @@
+import json
+import logging
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def build_index(docs_dir: Path, index_dir: Path) -> None:
+    """Build or update a simple JSON index from documents."""
+    index_dir.mkdir(parents=True, exist_ok=True)
+    index_file = index_dir / "index.json"
+    index = {}
+    if index_file.exists():
+        try:
+            index = json.loads(index_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logging.warning("Existing index is invalid JSON. Rebuilding.")
+            index = {}
+
+    updated_paths = set()
+    for path in docs_dir.glob("**/*"):
+        if path.is_file():
+            try:
+                content = path.read_text(encoding="utf-8")
+            except Exception as exc:  # pragma: no cover - unexpected read errors
+                logging.error("Failed to read %s: %s", path, exc)
+                continue
+            rel_path = str(path.relative_to(docs_dir))
+            index[rel_path] = content
+            updated_paths.add(rel_path)
+
+    # Remove entries for files that no longer exist
+    index = {k: v for k, v in index.items() if k in updated_paths}
+
+    index_file.write_text(
+        json.dumps(index, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    logging.info("Indexed %d documents into %s", len(index), index_file)
+
+
+def main() -> None:
+    load_dotenv()
+    docs_dir = Path(os.environ.get("DOCS_DIR", "docs"))
+    index_dir = Path(os.environ.get("INDEX_DIR", "index"))
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    logging.info("Starting ingestion from %s to %s", docs_dir, index_dir)
+    build_index(docs_dir, index_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/indexer/requirements.txt
+++ b/indexer/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv
+watchdog

--- a/indexer/watcher.py
+++ b/indexer/watcher.py
@@ -1,0 +1,51 @@
+import logging
+import os
+import time
+from pathlib import Path
+from threading import Timer
+
+import ingest
+from dotenv import load_dotenv
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+
+class DebouncedHandler(FileSystemEventHandler):
+    def __init__(self, delay: float):
+        self.delay = delay
+        self._timer: Timer | None = None
+
+    def on_any_event(self, event):  # type: ignore[override]
+        if self._timer:
+            self._timer.cancel()
+        self._timer = Timer(self.delay, self.run_ingest)
+        self._timer.start()
+
+    @staticmethod
+    def run_ingest() -> None:
+        logging.info("Changes detected. Running ingest.")
+        ingest.main()
+
+
+def main() -> None:
+    load_dotenv()
+    docs_dir = Path(os.environ.get("DOCS_DIR", "docs"))
+    debounce = float(os.environ.get("DEBOUNCE_SECONDS", "1.0"))
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    handler = DebouncedHandler(debounce)
+    observer = Observer()
+    observer.schedule(handler, str(docs_dir), recursive=True)
+    observer.start()
+    logging.info("Watching %s for changes", docs_dir)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ingest.py` to build/update a JSON index from DOCS_DIR into INDEX_DIR
- add `watcher.py` to debounce filesystem changes and trigger ingestion
- fix pre-commit hook revisions for isort and ruff

## Testing
- `python3 -m py_compile indexer/ingest.py indexer/watcher.py`
- `pre-commit run --files indexer/ingest.py indexer/watcher.py indexer/requirements.txt indexer/Dockerfile`
- `PYENV_VERSION=3.12.10 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cb7bc381c8329b9832f5a118b8935