### PR TITLE
Handle non-text files in indexer

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3601,4 +3601,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "4c71963f812387da76710522d666d27e6005b15e4fc0aa37a1028f345cbeffdb"
+content-hash = "cc0662f7064adacd0f595ea329f6c6862ea484bb71c8fefccdefd7f964ce0bd4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ llama-index = "^0.10.0"
 chainlit = "^1.0.0"
 watchdog = "^4.0.0"
 python-dotenv = "^1.0.0"
+pypdf = "^4.3.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,34 @@
+import json
+import sys
+from pathlib import Path
+
+from pypdf import PdfWriter
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from indexer.ingest import build_index
+
+
+def test_build_index_handles_pdf_and_skips_binary(tmp_path):
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    index_dir = tmp_path / "index"
+
+    # text file
+    (docs_dir / "a.txt").write_text("hello", encoding="utf-8")
+
+    # pdf file
+    pdf_path = docs_dir / "b.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    with pdf_path.open("wb") as fh:
+        writer.write(fh)
+
+    # binary file
+    (docs_dir / "c.bin").write_bytes(b"\x00\x01\x02")
+
+    build_index(docs_dir, index_dir)
+    data = json.loads((index_dir / "index.json").read_text(encoding="utf-8"))
+
+    assert data["a.txt"] == "hello"
+    assert "b.pdf" in data
+    assert "c.bin" not in data


### PR DESCRIPTION
## Summary
- support reading PDF documents and skip unsupported file types during indexing
- add `pypdf` dependency and tests for PDF and binary file handling

## Testing
- `pre-commit run --files indexer/ingest.py tests/test_ingest.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d06df65048329ad02f60253a6a136