### PR TITLE
fix: support python 3.13 bootstrap

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,8 +10,8 @@ bootstrap:
 	@. $(VENV)/bin/activate && \
 		curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
 		python /tmp/get-pip.py --force-reinstall && \
-		python -m pip install --upgrade pip setuptools wheel poetry && \
-		poetry install --no-root
+                python -m pip install --upgrade pip setuptools wheel poetry && \
+                PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 poetry install --no-root
 
 test:
 	@echo "== test =="


### PR DESCRIPTION
## Summary
- allow bootstrapping on Python 3.13 by enabling PyO3 forward compatibility

## Testing
- `make bootstrap`
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e41b5ea40832997d2425754b9a751