### PR TITLE
chore: ignore chainlit directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ htmlcov/
 .cache/
 *.cache
 
+# Chainlit
+.chainlit/
+
 # Poetry backup lock
 poetry.lock.bak
 


### PR DESCRIPTION
## Summary
- ignore `.chainlit/` directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e44c0860c8329af16e053572299d7