### PR TITLE
Use pyenv version for bootstrap

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,17 +1,20 @@
 .PHONY: bootstrap test format format-fix clean
 
 VENV := .venv
+PYTHON_VERSION := $(shell cat .python-version 2>/dev/null)
 
 bootstrap:
 	@echo "== bootstrap =="
-	-@pyenv shell system 2>/dev/null || true
+	@if command -v pyenv >/dev/null && [ -n "$(PYTHON_VERSION)" ]; then \
+		pyenv shell $(PYTHON_VERSION) >/dev/null 2>&1 || true; \
+	fi
 	@rm -rf $(VENV)
 	@python3 -m venv $(VENV) --without-pip
 	@. $(VENV)/bin/activate && \
 		curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
 		python /tmp/get-pip.py --force-reinstall && \
-                python -m pip install --upgrade pip setuptools wheel poetry && \
-                PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 poetry install --no-root
+		python -m pip install --upgrade pip setuptools wheel poetry && \
+		PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 poetry install --no-root
 
 test:
 	@echo "== test =="


### PR DESCRIPTION
## Summary
- ensure `make bootstrap` uses pyenv's pinned Python version before creating the virtualenv
- avoid relying on system Python which could break pydantic-core builds on unsupported versions

## Testing
- `make bootstrap`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4e0df9608329862fe07b72575e10