### PR TITLE
fix: ensure indexer imports project modules

### DIFF
--- a/indexer/ingest.py
+++ b/indexer/ingest.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from pathlib import Path
+
+# Ensure the project root is on the import path when executed as a script.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from dotenv import load_dotenv
 


### PR DESCRIPTION
## Summary
- ensure project root is on `sys.path` when running indexer directly

## Testing
- `python indexer/ingest.py` *(fails: ImportError: llama_index with Ollama support is required)*
- `pytest` *(fails: ImportError: llama_index with Ollama support is required)*

------
https://chatgpt.com/codex/tasks/task_e_688f63744474832997f1750d6c196855