### PR TITLE
Fix ingest script for latest llama_index

### DIFF
--- a/core/adapters/llama_index/llama_index_adapter.py
+++ b/core/adapters/llama_index/llama_index_adapter.py
@@ -26,15 +26,18 @@ try:  # pragma: no cover - optional dependency
         SimpleDirectoryReader,
         StorageContext,
         VectorStoreIndex,
-        load_index_from_storage,
         get_response_synthesizer,
+        load_index_from_storage,
     )
     from llama_index.readers.file import ImageReader, PDFReader
+
     try:  # pragma: no cover - optional Ollama support
         from llama_index.llms.ollama import Ollama
     except Exception:  # pragma: no cover - legacy path or missing
         try:
-            from llama_index.legacy.llms.ollama import Ollama  # type: ignore[assignment]
+            from llama_index.legacy.llms.ollama import (
+                Ollama,  # type: ignore[assignment]
+            )
         except Exception:  # pragma: no cover - handled gracefully if missing
             Ollama = None  # type: ignore[assignment]
 except Exception:  # pragma: no cover - handled gracefully if missing


### PR DESCRIPTION
## Summary
- update LlamaIndex adapter for 0.10 import paths and Ollama fallback
- adjust service context and file reader setup for new APIs
- handle optional heavy dependencies gracefully

## Testing
- `python -m indexer.ingest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d8cd76ac8329b0b5437600f6e168