### PR TITLE
feat: add lightweight hashing embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ NUM_OUTPUT=512
 LLM_MODEL=llama3.1:latest
 OLLAMA_API_URL=http://localhost:11434
 
+# Embeddings
+EMBED_DIM=256
+
 # Retrieval / Thinking knobs
 RETRIEVAL_K=10
 FETCH_K=30

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ list):
 | ``INDEX_DIR`` | Where the persistent vector store is written |
 | ``LLM_MODEL`` / ``OLLAMA_API_URL`` | Model and endpoint used by the LlamaIndex ``Ollama`` LLM |
 | ``CHUNK_SIZE`` / ``CHUNK_OVERLAP`` | Document chunking parameters |
+| ``EMBED_DIM`` | Size of the lightweight hashing embedding vector |
 | ``RETRIEVAL_K`` / ``FETCH_K`` | Retrieval depth controls |
 | ``MAX_INPUT_SIZE`` / ``NUM_OUTPUT`` | Prompt and output token limits |
 | ``RESPONSE_MODE`` / ``THINKING_STEPS`` / ``TEMPERATURE`` | Response generation knobs |


### PR DESCRIPTION
## Summary
- add lightweight hashing-based embedding model to remove MockEmbedding warning and improve index quality
- expose `EMBED_DIM` configuration and document in README

## Testing
- `pre-commit run --files core/adapters/llama_index/llama_index_adapter.py`
- `pre-commit run --files .env.example README.md`
- `pytest`
- `python -m indexer.ingest`
- `python - <<'PY'
from core.adapters.llama_index.llama_index_adapter import LlamaIndexIndexer, LlamaIndexRetriever
from pathlib import Path
idx = LlamaIndexIndexer.load(Path('vectorstore/llama'))
retriever = LlamaIndexRetriever(idx)
res = retriever.retrieve('Kartoffeln')
print(len(res), 'nodes retrieved')
print(res[0].metadata.get('file_name'), res[0].text[:60])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6890e1cf87248329a7c32332fc769d85