### PR TITLE
Fix chainlit config error

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
-chainlit
+# Pin Chainlit to a version compatible with Pydantic 2.x
+chainlit>=2.6.5,<3
 llama-index>=0.13.0,<0.14.0
 llama-index-llms-ollama>=0.7.0,<0.8.0
 python-dotenv


### PR DESCRIPTION
## Summary
- pin Chainlit to v2.6.5 to avoid Pydantic CodeSettings initialization error

## Testing
- `chainlit run backend/app.py --headless --port 8002`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68923b4699988329bf2de0689fadf0c6