### PR TITLE
Use Python 3.12 for Chainlit runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ python -m indexer.ingest
 # alternatively keep it up to date
 # python -m indexer.watcher
 
-# start the chat UI
-chainlit run backend/app.py
+# start the chat UI (use ``python -m`` so runtime patches are applied)
+python -m chainlit run backend/app.py
 ```
 
 The backend expects an [Ollama](https://ollama.ai) server listening on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
 
   backend:
     working_dir: /workspace
-    image: python:3.13-slim
-    command: bash -lc "pip install --no-cache-dir -r backend/requirements.txt && chainlit run backend/app.py"
+    image: python:3.12-slim
+    command: bash -lc "pip install --no-cache-dir -r backend/requirements.txt && python -m chainlit run backend/app.py"
     ports:
       - "8000:8000"
     env_file: .env

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- pin Docker images to Python 3.12 and invoke Chainlit as a module so our runtime patch is applied
- document using `python -m chainlit` when running the backend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68924c491a688329ae80a0f87d00d572