### PR TITLE
feat: make Ollama timeout configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ NUM_OUTPUT=512
 # LLM / Ollama
 LLM_MODEL=llama3.1:latest
 OLLAMA_API_URL=http://localhost:11434
+LLM_REQUEST_TIMEOUT=120
 
 # Embeddings
 EMBED_DIM=256

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ list):
 | ``DOCS_DIR`` | Directory containing the source documents |
 | ``INDEX_DIR`` | Where the persistent vector store is written |
 | ``LLM_MODEL`` / ``OLLAMA_API_URL`` | Model and endpoint used by the LlamaIndex ``Ollama`` LLM |
+| ``LLM_REQUEST_TIMEOUT`` | Seconds to wait for the LlamaIndex ``Ollama`` LLM |
 | ``CHUNK_SIZE`` / ``CHUNK_OVERLAP`` | Document chunking parameters |
 | ``EMBED_DIM`` | Size of the lightweight hashing embedding vector |
 | ``RETRIEVAL_K`` / ``FETCH_K`` | Retrieval depth controls |

--- a/core/adapters/llama_index/llama_index_adapter.py
+++ b/core/adapters/llama_index/llama_index_adapter.py
@@ -113,6 +113,7 @@ def _configure_settings_from_env() -> None:
             model=env.get("LLM_MODEL", "llama3.1:latest"),
             base_url=env.get("OLLAMA_API_URL", "http://localhost:11434"),
             temperature=float(env.get("TEMPERATURE", 0.1)),
+            request_timeout=float(env.get("LLM_REQUEST_TIMEOUT", 120.0)),
         )
 
     embed_dim = int(env.get("EMBED_DIM", 256))


### PR DESCRIPTION
## Summary
- allow configuring Ollama request_timeout via `LLM_REQUEST_TIMEOUT`
- document the new environment variable

## Testing
- `pre-commit run --files core/adapters/llama_index/llama_index_adapter.py README.md .env.example`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68931ce47a848329adf898a5bb42dcd3