### PR TITLE
Add German translations for Chainlit UI

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -1,0 +1,129 @@
+[project]
+# List of environment variables to be provided by each user to use the app.
+user_env = []
+
+# Duration (in seconds) during which the session is saved when the connection is lost
+session_timeout = 3600
+
+# Duration (in seconds) of the user session expiry
+user_session_timeout = 1296000  # 15 days
+
+# Enable third parties caching (e.g., LangChain cache)
+cache = false
+
+# Authorized origins
+allow_origins = ["*"]
+
+[features]
+# Process and display HTML in messages. This can be a security risk (see https://stackoverflow.com/questions/19603097/why-is-it-dangerous-to-render-user-generated-html-or-javascript)
+unsafe_allow_html = false
+
+# Process and display mathematical expressions. This can clash with "$" characters in messages.
+latex = false
+
+# Autoscroll new user messages at the top of the window
+user_message_autoscroll = true
+
+# Automatically tag threads with the current chat profile (if a chat profile is used)
+auto_tag_thread = true
+
+# Allow users to edit their own messages
+edit_message = true
+
+# Authorize users to spontaneously upload files with messages
+[features.spontaneous_file_upload]
+    enabled = true
+    # Define accepted file types using MIME types
+    # Examples:
+    # 1. For specific file types:
+    #    accept = ["image/jpeg", "image/png", "application/pdf"]
+    # 2. For all files of certain type:
+    #    accept = ["image/*", "audio/*", "video/*"]
+    # 3. For specific file extensions:
+    #    accept = { "application/octet-stream" = [".xyz", ".pdb"] }
+    # Note: Using "*/*" is not recommended as it may cause browser warnings
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
+
+[features.audio]
+    # Sample rate of the audio
+    sample_rate = 24000
+
+[features.mcp.sse]
+    enabled = true
+
+[features.mcp.streamable-http]
+    enabled = true
+
+[features.mcp.stdio]
+    enabled = true
+    # Only the executables in the allow list can be used for MCP stdio server.
+    # Only need the base name of the executable, e.g. "npx", not "/usr/bin/npx".
+    # Please don't comment this line for now, we need it to parse the executable name.
+    allowed_executables = [ "npx", "uvx" ]
+
+[UI]
+# Name of the assistant.
+name = "Assistant"
+
+# default_theme = "dark"
+
+# layout = "wide"
+
+# default_sidebar_state = "open"
+
+# Description of the assistant. This is used for HTML tags.
+# description = ""
+
+# Chain of Thought (CoT) display mode. Can be "hidden", "tool_call" or "full".
+cot = "full"
+
+# Specify a CSS file that can be used to customize the user interface.
+# The CSS file can be served from the public directory or via an external link.
+# custom_css = "/public/test.css"
+
+# Specify additional attributes for a custom CSS file
+# custom_css_attributes = "media=\"print\""
+
+# Specify a JavaScript file that can be used to customize the user interface.
+# The JavaScript file can be served from the public directory.
+# custom_js = "/public/test.js"
+
+# The style of alert boxes. Can be "classic" or "modern".
+alert_style = "classic"
+
+# Specify additional attributes for custom JS file
+# custom_js_attributes = "async type = \"module\""
+
+# Custom login page image, relative to public directory or external URL
+# login_page_image = "/public/custom-background.jpg"
+
+# Custom login page image filter (Tailwind internal filters, no dark/light variants)
+# login_page_image_filter = "brightness-50 grayscale"
+# login_page_image_dark_filter = "contrast-200 blur-sm"
+
+
+# Specify a custom meta image url.
+# custom_meta_image_url = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
+
+# Load assistant logo directly from URL.
+logo_file_url = ""
+
+# Load assistant avatar image directly from URL.
+default_avatar_file_url = ""
+
+# Specify a custom build directory for the frontend.
+# This can be used to customize the frontend code.
+# Be careful: If this is a relative path, it should not start with a slash.
+# custom_build = "./public/build"
+
+# Specify optional one or more custom links in the header.
+# [[UI.header_links]]
+#     name = "Issues"
+#     display_name = "Report Issue"
+#     icon_url = "https://avatars.githubusercontent.com/u/128686189?s=200&v=4"
+#     url = "https://github.com/Chainlit/chainlit/issues"
+
+[meta]
+generated_by = "2.6.5"

--- a/.chainlit/translations/de-DE.json
+++ b/.chainlit/translations/de-DE.json
@@ -1,0 +1,226 @@
+{
+    "common": {
+        "actions": {
+            "cancel": "Abbrechen",
+            "confirm": "Bestätigen",
+            "continue": "Weiter",
+            "goBack": "Zurück",
+            "reset": "Zurücksetzen",
+            "submit": "Absenden"
+        },
+        "status": {
+            "loading": "Laden...",
+            "error": {
+                "default": "Es ist ein Fehler aufgetreten",
+                "serverConnection": "Server konnte nicht erreicht werden"
+            }
+        }
+    },
+    "auth": {
+        "login": {
+            "title": "Melde dich an, um die App zu nutzen",
+            "form": {
+                "email": {
+                    "label": "E-Mail-Adresse",
+                    "required": "E-Mail ist ein Pflichtfeld"
+                },
+                "password": {
+                    "label": "Passwort",
+                    "required": "Passwort ist ein Pflichtfeld"
+                },
+                "actions": {
+                    "signin": "Anmelden"
+                },
+                "alternativeText": {
+                    "or": "ODER"
+                }
+            },
+            "errors": {
+                "default": "Anmeldung nicht möglich",
+                "signin": "Versuche dich mit einem anderen Konto anzumelden",
+                "oauthSignin": "Versuche dich mit einem anderen Konto anzumelden",
+                "redirectUriMismatch": "Die Redirect-URI stimmt nicht mit der OAuth-App-Konfiguration überein",
+                "oauthCallback": "Versuche dich mit einem anderen Konto anzumelden",
+                "oauthCreateAccount": "Versuche dich mit einem anderen Konto anzumelden",
+                "emailCreateAccount": "Versuche dich mit einem anderen Konto anzumelden",
+                "callback": "Versuche dich mit einem anderen Konto anzumelden",
+                "oauthAccountNotLinked": "Um deine Identität zu bestätigen, melde dich mit dem gleichen Konto an, das du ursprünglich verwendet hast",
+                "emailSignin": "Die E-Mail konnte nicht gesendet werden",
+                "emailVerify": "Bitte verifiziere deine E-Mail, eine neue E-Mail wurde gesendet",
+                "credentialsSignin": "Anmeldung fehlgeschlagen. Überprüfe, ob die angegebenen Daten korrekt sind",
+                "sessionRequired": "Bitte melde dich an, um auf diese Seite zuzugreifen"
+            }
+        },
+        "provider": {
+            "continue": "Weiter mit {{provider}}"
+        }
+    },
+    "chat": {
+        "input": {
+            "placeholder": "Gib deine Nachricht hier ein...",
+            "actions": {
+                "send": "Nachricht senden",
+                "stop": "Aufgabe stoppen",
+                "attachFiles": "Dateien anhängen"
+            }
+        },
+        "speech": {
+            "start": "Aufnahme starten",
+            "stop": "Aufnahme stoppen",
+            "connecting": "Verbindung wird hergestellt"
+        },
+        "fileUpload": {
+            "dragDrop": "Dateien hierher ziehen und ablegen",
+            "browse": "Dateien durchsuchen",
+            "sizeLimit": "Limit:",
+            "errors": {
+                "failed": "Hochladen fehlgeschlagen",
+                "cancelled": "Hochladen abgebrochen von",
+                "fileTooLarge": "Datei überschreitet die Größenbegrenzung",
+                "unsupportedType": "Dateityp wird nicht unterstützt"
+            }
+        },
+        "errors": {
+            "sendMessage": "Nachricht konnte nicht gesendet werden",
+            "loadHistory": "Verlauf konnte nicht geladen werden"
+        },
+        "messages": {
+            "status": {
+                "using": "Wird verwendet",
+                "used": "Verwendet"
+            },
+            "actions": {
+                "copy": {
+                    "button": "In Zwischenablage kopieren",
+                    "success": "Kopiert!"
+                }
+            },
+            "feedback": {
+                "positive": "Hilfreich",
+                "negative": "Nicht hilfreich",
+                "edit": "Feedback bearbeiten",
+                "dialog": {
+                    "title": "Kommentar hinzufügen",
+                    "submit": "Feedback senden"
+                },
+                "status": {
+                    "updating": "Aktualisiere",
+                    "updated": "Feedback aktualisiert",
+                    "error": "Feedback konnte nicht aktualisiert werden"
+                }
+            }
+        },
+        "history": {
+            "title": "Letzte Eingaben",
+            "empty": "So leer...",
+            "show": "Verlauf anzeigen"
+        },
+        "settings": {
+            "title": "Einstellungsbereich"
+        },
+        "watermark": "LLMs können Fehler machen. Prüfe wichtige Informationen."
+    },
+    "threadHistory": {
+        "sidebar": {
+            "title": "Frühere Chats",
+            "filters": {
+                "search": "Suche",
+                "placeholder": "Konversationen durchsuchen..."
+            },
+            "timeframes": {
+                "today": "Heute",
+                "yesterday": "Gestern",
+                "previous7days": "Letzte 7 Tage",
+                "previous30days": "Letzte 30 Tage"
+            },
+            "empty": "Keine Threads gefunden",
+            "actions": {
+                "close": "Seitenleiste schließen",
+                "open": "Seitenleiste öffnen"
+            }
+        },
+        "thread": {
+            "untitled": "Unbenannte Konversation",
+            "menu": {
+                "rename": "Umbenennen",
+                "delete": "Löschen"
+            },
+            "actions": {
+                "delete": {
+                    "title": "Löschen bestätigen",
+                    "description": "Dies löscht den Thread sowie dessen Nachrichten und Elemente. Diese Aktion kann nicht rückgängig gemacht werden",
+                    "success": "Chat gelöscht",
+                    "inProgress": "Chat wird gelöscht",
+                    "error": "Fehler beim Löschen des Chats"
+                },
+                "rename": {
+                    "title": "Thread umbenennen",
+                    "description": "Gib einen neuen Namen für diesen Thread ein",
+                    "form": {
+                        "name": {
+                            "label": "Name",
+                            "placeholder": "Neuen Namen eingeben"
+                        }
+                    },
+                    "success": "Thread umbenannt!",
+                    "inProgress": "Thread wird umbenannt",
+                    "error": "Fehler beim Umbenennen des Threads"
+                }
+            }
+        }
+    },
+    "navigation": {
+        "header": {
+            "chat": "Chat",
+            "readme": "Readme",
+            "theme": {
+                "light": "Helles Design",
+                "dark": "Dunkles Design",
+                "system": "Systemeinstellung übernehmen"
+            }
+        },
+        "newChat": {
+            "button": "Neuer Chat",
+            "dialog": {
+                "title": "Neuen Chat erstellen",
+                "description": "Dies löscht deinen aktuellen Chatverlauf. Bist du sicher, dass du fortfahren möchtest?",
+                "tooltip": "Neuer Chat"
+            }
+        },
+        "user": {
+            "menu": {
+                "settings": "Einstellungen",
+                "settingsKey": "E",
+                "apiKeys": "API-Schlüssel",
+                "logout": "Abmelden"
+            }
+        }
+    },
+    "apiKeys": {
+        "title": "Benötigte API-Schlüssel",
+        "description": "Für die Nutzung dieser App sind die folgenden API-Schlüssel erforderlich. Die Schlüssel werden im lokalen Speicher deines Geräts gespeichert.",
+        "success": {
+            "saved": "Erfolgreich gespeichert"
+        },
+        "errors": {
+            "save": "Speichern der Schlüssel fehlgeschlagen"
+        }
+    },
+    "alerts": {
+        "info": "Info",
+        "note": "Hinweis",
+        "tip": "Tipp",
+        "important": "Wichtig",
+        "warning": "Warnung",
+        "caution": "Achtung",
+        "debug": "Debug",
+        "example": "Beispiel",
+        "success": "Erfolg",
+        "help": "Hilfe",
+        "idea": "Idee",
+        "pending": "Ausstehend",
+        "security": "Sicherheit",
+        "beta": "Beta",
+        "best-practice": "Best Practice"
+    }
+}

--- a/.chainlit/translations/en-US.json
+++ b/.chainlit/translations/en-US.json
@@ -1,0 +1,226 @@
+{
+    "common": {
+        "actions": {
+            "cancel": "Cancel",
+            "confirm": "Confirm",
+            "continue": "Continue",
+            "goBack": "Go Back",
+            "reset": "Reset",
+            "submit": "Submit"
+        },
+        "status": {
+            "loading": "Loading...",
+            "error": {
+                "default": "An error occurred",
+                "serverConnection": "Could not reach the server"
+            }
+        }
+    },
+    "auth": {
+        "login": {
+            "title": "Login to access the app",
+            "form": {
+                "email": {
+                    "label": "Email address",
+                    "required": "email is a required field"
+                },
+                "password": {
+                    "label": "Password",
+                    "required": "password is a required field"
+                },
+                "actions": {
+                    "signin": "Sign In"
+                },
+                "alternativeText": {
+                    "or": "OR"
+                }
+            },
+            "errors": {
+                "default": "Unable to sign in",
+                "signin": "Try signing in with a different account",
+                "oauthSignin": "Try signing in with a different account",
+                "redirectUriMismatch": "The redirect URI is not matching the oauth app configuration",
+                "oauthCallback": "Try signing in with a different account",
+                "oauthCreateAccount": "Try signing in with a different account",
+                "emailCreateAccount": "Try signing in with a different account",
+                "callback": "Try signing in with a different account",
+                "oauthAccountNotLinked": "To confirm your identity, sign in with the same account you used originally",
+                "emailSignin": "The e-mail could not be sent",
+                "emailVerify": "Please verify your email, a new email has been sent",
+                "credentialsSignin": "Sign in failed. Check the details you provided are correct",
+                "sessionRequired": "Please sign in to access this page"
+            }
+        },
+        "provider": {
+            "continue": "Continue with {{provider}}"
+        }
+    },
+    "chat": {
+        "input": {
+            "placeholder": "Type your message here...",
+            "actions": {
+                "send": "Send message",
+                "stop": "Stop Task",
+                "attachFiles": "Attach files"
+            }
+        },
+        "speech": {
+            "start": "Start recording",
+            "stop": "Stop recording",
+            "connecting": "Connecting"
+        },
+        "fileUpload": {
+            "dragDrop": "Drag and drop files here",
+            "browse": "Browse Files",
+            "sizeLimit": "Limit:",
+            "errors": {
+                "failed": "Failed to upload",
+                "cancelled": "Cancelled upload of",
+                "fileTooLarge": "File exceeds size limit",
+                "unsupportedType": "Unsupported file type"
+            }
+        },
+        "errors": {
+            "sendMessage": "Failed to send message",
+            "loadHistory": "Failed to load history"
+        },
+        "messages": {
+            "status": {
+                "using": "Using",
+                "used": "Used"
+            },
+            "actions": {
+                "copy": {
+                    "button": "Copy to clipboard",
+                    "success": "Copied!"
+                }
+            },
+            "feedback": {
+                "positive": "Helpful",
+                "negative": "Not helpful",
+                "edit": "Edit feedback",
+                "dialog": {
+                    "title": "Add a comment",
+                    "submit": "Submit feedback"
+                },
+                "status": {
+                    "updating": "Updating",
+                    "updated": "Feedback updated",
+                    "error": "Failed to update feedback"
+                }
+            }
+        },
+        "history": {
+            "title": "Last Inputs",
+            "empty": "Such empty...",
+            "show": "Show history"
+        },
+        "settings": {
+            "title": "Settings panel"
+        },
+        "watermark": "LLMs can make mistakes. Check important info."
+    },
+    "threadHistory": {
+        "sidebar": {
+            "title": "Past Chats",
+            "filters": {
+                "search": "Search",
+                "placeholder": "Search conversations..."
+            },
+            "timeframes": {
+                "today": "Today",
+                "yesterday": "Yesterday",
+                "previous7days": "Previous 7 days",
+                "previous30days": "Previous 30 days"
+            },
+            "empty": "No threads found",
+            "actions": {
+                "close": "Close sidebar",
+                "open": "Open sidebar"
+            }
+        },
+        "thread": {
+            "untitled": "Untitled Conversation",
+            "menu": {
+                "rename": "Rename",
+                "delete": "Delete"
+            },
+            "actions": {
+                "delete": {
+                    "title": "Confirm deletion",
+                    "description": "This will delete the thread as well as its messages and elements. This action cannot be undone",
+                    "success": "Chat deleted",
+                    "inProgress": "Deleting chat",
+                    "error": "Failed to delete chat"
+                },
+                "rename": {
+                    "title": "Rename Thread",
+                    "description": "Enter a new name for this thread",
+                    "form": {
+                        "name": {
+                            "label": "Name",
+                            "placeholder": "Enter new name"
+                        }
+                    },
+                    "success": "Thread renamed!",
+                    "inProgress": "Renaming thread",
+                    "error": "Failed to rename thread"
+                }
+            }
+        }
+    },
+    "navigation": {
+        "header": {
+            "chat": "Chat",
+            "readme": "Readme",
+            "theme": {
+                "light": "Light Theme",
+                "dark": "Dark Theme",
+                "system": "Follow System"
+            }
+        },
+        "newChat": {
+            "button": "New Chat",
+            "dialog": {
+                "title": "Create New Chat",
+                "description": "This will clear your current chat history. Are you sure you want to continue?",
+                "tooltip": "New Chat"
+            }
+        },
+        "user": {
+            "menu": {
+                "settings": "Settings",
+                "settingsKey": "S",
+                "apiKeys": "API Keys",
+                "logout": "Logout"
+            }
+        }
+    },
+    "apiKeys": {
+        "title": "Required API Keys",
+        "description": "To use this app, the following API keys are required. The keys are stored on your device's local storage.",
+        "success": {
+            "saved": "Saved successfully"
+        },
+        "errors": {
+            "save": "Failed to save keys"
+        }
+    },
+    "alerts": {
+        "info": "Info",
+        "note": "Note",
+        "tip": "Tip",
+        "important": "Important",
+        "warning": "Warning",
+        "caution": "Caution",
+        "debug": "Debug",
+        "example": "Example",
+        "success": "Success",
+        "help": "Help",
+        "idea": "Idea",
+        "pending": "Pending",
+        "security": "Security",
+        "beta": "Beta",
+        "best-practice": "Best Practice"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ htmlcov/
 .cache/
 *.cache
 
-# Chainlit
-.chainlit/
-
 # Vector store data
 vectorstore/
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -35,7 +35,7 @@ generator: LlamaIndexResponseGenerator | None = None
 def add_translation_alias() -> None:
     @cls.router.get("/_chainlit/project/translations", include_in_schema=False)
     async def legacy_project_translations(
-        language: str = Query(default="en-US", description="Language code")
+        language: str = Query(default="de-DE", description="Language code")
     ) -> dict:
         """Serve translation strings for legacy frontend paths."""
         translation = config.load_translation(language)


### PR DESCRIPTION
## Summary
- provide German translation file for all UI labels, placeholders, and error messages
- default translation endpoint to `de-DE`
- track Chainlit config and translations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894cb028d448329a6686d38061d0e97