### PR TITLE
Verify Ollama connectivity during settings setup

### DIFF
--- a/core/adapters/llama_index/llama_index_adapter.py
+++ b/core/adapters/llama_index/llama_index_adapter.py
@@ -107,14 +107,24 @@ def _configure_settings_from_env() -> None:
         chunk_size_limit=chunk_size,
     )
 
-    llm = None
-    if Ollama is not None:  # pragma: no branch - optional
+    if Ollama is None:  # pragma: no cover - optional dependency missing
+        raise RuntimeError("Ollama LLM is not available")
+
+    llm: Any
+    base_url = env.get("OLLAMA_API_URL", "http://localhost:11434")
+    try:  # pragma: no branch - optional
         llm = Ollama(
             model=env.get("LLM_MODEL", "llama3.1:latest"),
-            base_url=env.get("OLLAMA_API_URL", "http://localhost:11434"),
+            base_url=base_url,
             temperature=float(env.get("TEMPERATURE", 0.1)),
             request_timeout=float(env.get("LLM_REQUEST_TIMEOUT", 120.0)),
         )
+        # verify the Ollama server is reachable
+        llm.client.list()
+    except Exception as exc:  # pragma: no cover - network or init failure
+        raise RuntimeError(
+            f"Failed to connect to Ollama server at {base_url}"
+        ) from exc
 
     embed_dim = int(env.get("EMBED_DIM", 256))
     embed_model = HashingEmbedding(dim=embed_dim)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3,13 +3,28 @@ import sys
 from pathlib import Path
 
 llama_index = pytest.importorskip("llama_index")
-pytest.importorskip("llama_index.llms.ollama")
+from llama_index.llms.ollama import Ollama as RealOllama
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from indexer.ingest import build_index
 
 
-def test_build_index_runs(tmp_path):
+class DummyClient:
+    def list(self):
+        return {"models": []}
+
+
+class DummyOllama(RealOllama):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._client = DummyClient()
+
+
+def test_build_index_runs(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "core.adapters.llama_index.llama_index_adapter.Ollama", DummyOllama
+    )
+
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("hello", encoding="utf-8")

--- a/tests/test_llama_index_adapter.py
+++ b/tests/test_llama_index_adapter.py
@@ -1,0 +1,56 @@
+import pytest
+
+from core.adapters.llama_index import llama_index_adapter as adapter
+
+
+class DummyPromptHelper:
+    def __init__(self, **kwargs):
+        pass
+
+
+class DummySettings:
+    llm = None
+    embed_model = None
+    prompt_helper = None
+
+
+class DummyClient:
+    def __init__(self, fail=False):
+        self.fail = fail
+
+    def list(self):  # pragma: no cover - trivial
+        if self.fail:
+            raise OSError("boom")
+        return {"models": []}
+
+
+class DummyOllama:
+    def __init__(self, *_, fail=False, **__):
+        self.client = DummyClient(fail=fail)
+
+
+def _setup_env(monkeypatch, **ollama_kwargs):
+    monkeypatch.setattr(adapter, "PromptHelper", DummyPromptHelper)
+    monkeypatch.setattr(adapter, "Settings", DummySettings)
+    monkeypatch.setenv("EMBED_DIM", "16")
+    monkeypatch.setattr(adapter, "Ollama", lambda *a, **k: DummyOllama(*a, **k, **ollama_kwargs))
+
+
+def test_raises_when_ollama_missing(monkeypatch):
+    monkeypatch.setattr(adapter, "PromptHelper", DummyPromptHelper)
+    monkeypatch.setattr(adapter, "Settings", DummySettings)
+    monkeypatch.setattr(adapter, "Ollama", None)
+    with pytest.raises(RuntimeError, match="Ollama LLM is not available"):
+        adapter._configure_settings_from_env()
+
+
+def test_raises_when_server_unreachable(monkeypatch):
+    _setup_env(monkeypatch, fail=True)
+    with pytest.raises(RuntimeError, match="Failed to connect to Ollama server"):
+        adapter._configure_settings_from_env()
+
+
+def test_success_sets_llm(monkeypatch):
+    _setup_env(monkeypatch)
+    adapter._configure_settings_from_env()
+    assert isinstance(adapter.Settings.llm, DummyOllama)


### PR DESCRIPTION
## Summary
- Fail fast in `_configure_settings_from_env` when Ollama is missing or the server is unreachable
- Added unit tests covering missing LLM and connection failure scenarios
- Adjusted ingestion test to use a dummy Ollama client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ccf443088329b78b9bd6fd980523