### PR TITLE
Fix Docker setup to include Ollama service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,10 @@ NUM_OUTPUT=512
 
 # LLM / Ollama
 LLM_MODEL=llama3.1:latest
-OLLAMA_API_URL=http://localhost:11434
+# When using the Docker setup the Ollama service is reachable at
+# http://ollama:11434.  For local development without Docker change this to
+# http://localhost:11434.
+OLLAMA_API_URL=http://ollama:11434
 LLM_REQUEST_TIMEOUT=120
 
 # Embeddings

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The stack can be launched with Docker containers:
 # copy and adjust the configuration
 cp .env.example .env
 
-# build and start the indexer plus chat backend
+# build and start the indexer, Ollama LLM and chat backend
 docker compose up --build
 ```
 
@@ -63,10 +63,13 @@ python -m indexer.ingest
 python -m chainlit run backend/app.py
 ```
 
-The backend expects an [Ollama](https://ollama.ai) server listening on
-``http://localhost:11434`` (configurable via ``OLLAMA_API_URL``) with the
-``llama3.1:latest`` model downloaded. Adjust ``LLM_MODEL`` if you want to use
-another local model.
+The ``docker-compose.yml`` file starts an
+[Ollama](https://ollama.ai) service that the other components connect to via
+``OLLAMA_API_URL=http://ollama:11434``. For local development without Docker,
+run your own Ollama server on ``http://localhost:11434`` instead and adjust
+``OLLAMA_API_URL`` accordingly. Make sure the ``llama3.1:latest`` model is
+available in your Ollama instance or change ``LLM_MODEL`` to another local
+model.
 
 ## Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,14 @@
 version: "3.9"
 
 services:
+  ollama:
+    image: ollama/ollama:0.4.9
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    restart: unless-stopped
+
   indexer:
     build:
       context: .
@@ -9,6 +17,8 @@ services:
     volumes:
       - docs-data:/app/docs        # maps to DOCS_DIR inside ingest watcher
       - vectorstore-data:/app/vectorstore
+    depends_on:
+      - ollama
     restart: unless-stopped
 
   backend:
@@ -23,8 +33,10 @@ services:
       - vectorstore-data:/vectorstore
     depends_on:
       - indexer
+      - ollama
     restart: unless-stopped
 
 volumes:
   docs-data:
   vectorstore-data:
+  ollama-data:


### PR DESCRIPTION
## Summary
- add Ollama container and wire indexer/backend to it
- default OLLAMA_API_URL to the Ollama service and document usage
- update README with Docker instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894dced9a3c8329a20855f877ca15c7