### PR TITLE
Gracefully handle missing Ollama server

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,8 @@ from chainlit.config import config
 from chainlit.input_widget import Switch
 from dotenv import load_dotenv
 from fastapi import Query
+from llama_index.core import Settings
+from llama_index.core.llms.mock import MockLLM
 from llama_index.core.schema import NodeWithScore, TextNode
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -28,8 +30,6 @@ from core.adapters.llama_index.llama_index_adapter import (  # noqa: E402
     LlamaIndexRetriever,
     _configure_settings_from_env,
 )
-from llama_index.core import Settings
-from llama_index.core.llms.mock import MockLLM
 
 FEEDBACK_PATH = Path(__file__).with_name("feedback.log")
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -26,7 +26,10 @@ from core.adapters.llama_index.llama_index_adapter import (  # noqa: E402
     LlamaIndexIndexer,
     LlamaIndexResponseGenerator,
     LlamaIndexRetriever,
+    _configure_settings_from_env,
 )
+from llama_index.core import Settings
+from llama_index.core.llms.mock import MockLLM
 
 FEEDBACK_PATH = Path(__file__).with_name("feedback.log")
 
@@ -109,11 +112,25 @@ def _ingest_elements(elements: List[cl.Element]) -> None:
 @cl.on_chat_start
 async def on_chat_start() -> None:
     load_dotenv()
+    _configure_settings_from_env()
+
     if _load_index():
         await cl.Message(content="Index geladen. Stelle deine Frage!").send()
     else:
         await cl.Message(
             content="Kein Index gefunden. Bitte führe zuerst den Indexer aus."
+        ).send()
+
+    if isinstance(Settings.llm, MockLLM):
+        base_url = os.environ.get("OLLAMA_API_URL", "http://localhost:11434")
+        model = os.environ.get("LLM_MODEL", "llama3.1:latest")
+        await cl.Message(
+            content=(
+                f"Ollama-Server unter {base_url} nicht erreichbar. "
+                "Nutze MockLLM mit eingeschränkten Antworten. "
+                f"Starte Ollama z. B. mit `ollama serve` und lade das Modell `ollama pull {model}` "
+                "um echte Antworten zu erhalten."
+            )
         ).send()
 
     settings = await cl.ChatSettings(

--- a/core/adapters/llama_index/llama_index_adapter.py
+++ b/core/adapters/llama_index/llama_index_adapter.py
@@ -10,14 +10,14 @@ can be tuned without code changes.
 from __future__ import annotations
 
 import hashlib
+import logging
 import math
 import os
+import subprocess
+import time
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, List, Sequence
-import logging
-import subprocess
-import time
 
 from core.interfaces.evaluator import Evaluator
 from core.interfaces.indexer import Indexer
@@ -37,8 +37,8 @@ try:  # pragma: no cover - optional dependency
         load_index_from_storage,
     )
     from llama_index.core.embeddings import BaseEmbedding
-    from llama_index.readers.file import ImageReader, PDFReader
     from llama_index.core.llms.mock import MockLLM
+    from llama_index.readers.file import ImageReader, PDFReader
 
     try:  # pragma: no cover - optional Ollama support
         from llama_index.llms.ollama import Ollama

--- a/tests/test_llama_index_adapter.py
+++ b/tests/test_llama_index_adapter.py
@@ -1,4 +1,3 @@
-import pytest
 from llama_index.core.llms.mock import MockLLM
 
 from core.adapters.llama_index import llama_index_adapter as adapter
@@ -64,7 +63,9 @@ def test_autostart_attempt(monkeypatch):
 
     _setup_env(monkeypatch, fail=True)
     monkeypatch.setenv("OLLAMA_AUTO_START", "1")
-    monkeypatch.setattr(adapter.subprocess, "Popen", lambda *a, **k: started.__setitem__("called", True))
+    monkeypatch.setattr(
+        adapter.subprocess, "Popen", lambda *a, **k: started.__setitem__("called", True)
+    )
     monkeypatch.setattr(adapter.time, "sleep", lambda _: None)
 
     adapter._configure_settings_from_env()

--- a/tests/test_llama_index_adapter.py
+++ b/tests/test_llama_index_adapter.py
@@ -57,3 +57,16 @@ def test_success_sets_llm(monkeypatch):
     _setup_env(monkeypatch)
     adapter._configure_settings_from_env()
     assert isinstance(adapter.Settings.llm, DummyOllama)
+
+
+def test_autostart_attempt(monkeypatch):
+    started = {"called": False}
+
+    _setup_env(monkeypatch, fail=True)
+    monkeypatch.setenv("OLLAMA_AUTO_START", "1")
+    monkeypatch.setattr(adapter.subprocess, "Popen", lambda *a, **k: started.__setitem__("called", True))
+    monkeypatch.setattr(adapter.time, "sleep", lambda _: None)
+
+    adapter._configure_settings_from_env()
+    assert started["called"]
+    assert isinstance(adapter.Settings.llm, MockLLM)

--- a/tests/test_llama_index_adapter.py
+++ b/tests/test_llama_index_adapter.py
@@ -1,4 +1,5 @@
 import pytest
+from llama_index.core.llms.mock import MockLLM
 
 from core.adapters.llama_index import llama_index_adapter as adapter
 
@@ -38,18 +39,18 @@ def _setup_env(monkeypatch, **ollama_kwargs):
     )
 
 
-def test_raises_when_ollama_missing(monkeypatch):
+def test_falls_back_when_ollama_missing(monkeypatch):
     monkeypatch.setattr(adapter, "PromptHelper", DummyPromptHelper)
     monkeypatch.setattr(adapter, "Settings", DummySettings)
     monkeypatch.setattr(adapter, "Ollama", None)
-    with pytest.raises(RuntimeError, match="Ollama LLM is not available"):
-        adapter._configure_settings_from_env()
+    adapter._configure_settings_from_env()
+    assert isinstance(adapter.Settings.llm, MockLLM)
 
 
-def test_raises_when_server_unreachable(monkeypatch):
+def test_falls_back_when_server_unreachable(monkeypatch):
     _setup_env(monkeypatch, fail=True)
-    with pytest.raises(RuntimeError, match="Failed to connect to Ollama server"):
-        adapter._configure_settings_from_env()
+    adapter._configure_settings_from_env()
+    assert isinstance(adapter.Settings.llm, MockLLM)
 
 
 def test_success_sets_llm(monkeypatch):


### PR DESCRIPTION
## Summary
- handle missing or unreachable Ollama server by falling back to MockLLM
- update tests for new fallback behaviour

## Testing
- `python -m indexer.ingest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e19d55948329b8f4deb8aa3db3b0