### PR TITLE
fix: fallback when python-dotenv missing

### DIFF
--- a/indexer/ingest.py
+++ b/indexer/ingest.py
@@ -13,7 +13,17 @@ import logging
 import os
 from pathlib import Path
 
-from dotenv import load_dotenv
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - fallback
+
+    def load_dotenv(*_: object, **__: object) -> None:
+        """Fallback no-op if python-dotenv is not installed."""
+
+        logging.getLogger(__name__).warning(
+            "python-dotenv not installed; skipping .env loading"
+        )
+
 
 from core.adapters.llama_index.llama_index_adapter import LlamaIndexIndexer
 


### PR DESCRIPTION
## Summary
- avoid crash if `python-dotenv` isn't installed by providing a no-op fallback and warning

## Testing
- `pre-commit run --files indexer/ingest.py`
- `python -m indexer.ingest`

------
https://chatgpt.com/codex/tasks/task_e_6894f71d896c83299db0ef80c1030410