### PR TITLE
feat: make internet search async

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,7 +11,7 @@ from typing import List
 
 import chainlit as cl
 import chainlit.server as cls
-import requests
+import httpx
 from chainlit.config import config
 from chainlit.input_widget import Switch
 from dotenv import load_dotenv
@@ -34,18 +34,19 @@ from core.adapters.llama_index.llama_index_adapter import (  # noqa: E402
 FEEDBACK_PATH = Path(__file__).with_name("feedback.log")
 
 
-def internet_search(query: str) -> str:
+async def internet_search(query: str) -> str:
     """Return a short snippet from an internet search."""
 
     try:  # pragma: no cover - network call
-        resp = requests.get(
-            "https://api.duckduckgo.com/",
-            params={"q": query, "format": "json"},
-            timeout=10,
-        )
-        if resp.ok:
-            data = resp.json()
-            return data.get("AbstractText") or ""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://api.duckduckgo.com/",
+                params={"q": query, "format": "json"},
+                timeout=10,
+            )
+            if resp.is_success:
+                data = resp.json()
+                return data.get("AbstractText") or ""
     except Exception:
         pass
     return ""
@@ -157,7 +158,7 @@ async def on_message(message: cl.Message) -> None:
         nodes: List[NodeWithScore] = list(retriever.retrieve(message.content))
 
         if cl.user_session.get("internet"):
-            snippet = internet_search(message.content)
+            snippet = await internet_search(message.content)
             if snippet:
                 nodes.append(
                     NodeWithScore(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ llama-index>=0.13.0,<0.14.0
 llama-index-llms-ollama>=0.7.0,<0.8.0
 python-dotenv
 uptrace>=1.34.0,<1.35.0
+httpx>=0.28.0,<0.29.0


### PR DESCRIPTION
## Summary
- replace synchronous requests call with async httpx client
- await internet search and hook in on_message
- add httpx dependency for backend

## Testing
- `PYENV_VERSION=3.12.10 pytest` *(fails: ModuleNotFoundError: No module named 'llama_index')*


------
https://chatgpt.com/codex/tasks/task_e_6895c9f01ff4832991bbf08ac2fdc227