### PR TITLE
Use asyncio threads for retrieval and generation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import sys
@@ -154,10 +155,11 @@ async def on_message(message: cl.Message) -> None:
     cl.user_session.set("last_user_message", message.content)
 
     try:
-        nodes: List[NodeWithScore] = list(retriever.retrieve(message.content))
+        nodes = await asyncio.to_thread(retriever.retrieve, message.content)
+        nodes = list(nodes)
 
         if cl.user_session.get("internet"):
-            snippet = internet_search(message.content)
+            snippet = await asyncio.to_thread(internet_search, message.content)
             if snippet:
                 nodes.append(
                     NodeWithScore(
@@ -165,7 +167,7 @@ async def on_message(message: cl.Message) -> None:
                         score=0.2,
                     )
                 )
-        answer = generator.generate(message.content, nodes)
+        answer = await asyncio.to_thread(generator.generate, message.content, nodes)
     except Exception:
         logger.exception("Error during retrieval/generation")
         await cl.Message(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ llama-index>=0.13.0,<0.14.0
 llama-index-llms-ollama>=0.7.0,<0.8.0
 python-dotenv
 uptrace>=1.34.0,<1.35.0
+httpx>=0.28.0,<0.29.0


### PR DESCRIPTION
## Summary
- Avoid blocking the Chainlit event loop by moving index retrieval and answer generation to `asyncio.to_thread`
- Stream responses only after awaiting background work

## Testing
- `PYENV_VERSION=3.11.12 black backend/app.py`
- `PYENV_VERSION=3.11.12 PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895c9f064888329aa80f6a31f2a7153