### PR TITLE
fix: remove deprecated stream flag in chainlit message

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -192,7 +192,7 @@ async def on_message(message: cl.Message) -> None:
     if sources:
         answer = f"{answer}\n\nQuellen: {sources}"
 
-    sent = cl.Message(content="", stream=True)
+    sent = cl.Message(content="")
     await sent.send()
     for token in answer.split():
         await sent.stream_token(token + " ")


### PR DESCRIPTION
## Summary
- remove deprecated `stream` flag when creating chainlit messages to avoid runtime TypeError

## Testing
- `PYENV_VERSION=3.12.10 python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895efc328708329bdeff62cb14ebff7