### PR TITLE
Fix Chainlit Action payload field

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -197,10 +197,10 @@ async def on_message(message: cl.Message) -> None:
     for token in answer.split():
         await sent.stream_token(token + " ")
     actions = [
-        cl.Action(name="copy", value=answer, label="Copy"),
-        cl.Action(name="retry", value=message.content, label="Retry"),
-        cl.Action(name="vote", value="up", label="👍"),
-        cl.Action(name="vote", value="down", label="👎"),
+        cl.Action(name="copy", payload=answer, label="Copy"),
+        cl.Action(name="retry", payload=message.content, label="Retry"),
+        cl.Action(name="vote", payload="up", label="👍"),
+        cl.Action(name="vote", payload="down", label="👎"),
     ]
     await sent.update(actions=actions)
 
@@ -214,7 +214,7 @@ async def retry_callback(action: cl.Action) -> None:
 
 @cl.action_callback("vote")
 async def vote_callback(action: cl.Action) -> None:
-    if action.value == "down":
+    if action.payload == "down":
         detail = await cl.AskUserMessage(content="Bitte beschreibe das Problem.").send()
         detail_content = (
             detail.get("content", "")


### PR DESCRIPTION
## Summary
- update chainlit actions to use `payload` instead of deprecated `value`
- adjust vote callback to read `payload`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961fc406f88329b322aa4c33680ea7