### PR TITLE
feat: add async streaming for generator

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -199,7 +199,7 @@ async def on_message(message: cl.Message) -> None:
                     loop.call_soon_threadsafe(queue.put_nowait, token)
                 loop.call_soon_threadsafe(queue.put_nowait, None)
 
-            producer = asyncio.create_task(asyncio.to_thread(produce_sync))
+            producer = asyncio.to_thread(produce_sync)
 
         await asyncio.gather(producer, consumer)
     except Exception:

--- a/core/adapters/llama_index/llama_index_adapter.py
+++ b/core/adapters/llama_index/llama_index_adapter.py
@@ -17,7 +17,7 @@ import subprocess
 import time
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Any, List, Sequence
+from typing import Any, AsyncIterator, Iterator, List, Sequence
 
 from core.interfaces.evaluator import Evaluator
 from core.interfaces.indexer import Indexer
@@ -294,7 +294,9 @@ class LlamaIndexResponseGenerator(ResponseGenerator):
         response = self.synthesizer.synthesize(query, documents)
         return str(response)
 
-    def generate_stream(self, query: str, documents: Sequence[Any]):
+    def generate_stream(
+        self, query: str, documents: Sequence[Any]
+    ) -> Iterator[str]:
         """Yield tokens from the synthesized response as they are produced."""
 
         if self.thinking_steps > 1:
@@ -307,7 +309,9 @@ class LlamaIndexResponseGenerator(ResponseGenerator):
             for token in gen:
                 yield token
 
-    async def agenerate_stream(self, query: str, documents: Sequence[Any]):
+    async def agenerate_stream(
+        self, query: str, documents: Sequence[Any]
+    ) -> AsyncIterator[str]:
         """Asynchronously yield tokens from the synthesized response.
 
         Falls ``llama_index`` eine native asynchrone Streaming-Methode

--- a/core/interfaces/response_generator.py
+++ b/core/interfaces/response_generator.py
@@ -1,7 +1,7 @@
 """Core interface for turning retrieved context into an answer."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Sequence
+from typing import Any, AsyncIterator, Iterator, Sequence
 
 
 class ResponseGenerator(ABC):
@@ -10,3 +10,27 @@ class ResponseGenerator(ABC):
     @abstractmethod
     def generate(self, query: str, documents: Sequence[Any]) -> str:
         """Return an answer to ``query`` based on ``documents``."""
+
+    def generate_stream(
+        self, query: str, documents: Sequence[Any]
+    ) -> Iterator[str]:
+        """Yield tokens for the answer.
+
+        The default implementation falls back to :meth:`generate`.
+        Implementations that support token streaming should override this.
+        """
+
+        yield self.generate(query, documents)
+
+    async def agenerate_stream(
+        self, query: str, documents: Sequence[Any]
+    ) -> AsyncIterator[str]:
+        """Asynchronously yield tokens for the answer.
+
+        This implementation simply iterates over the synchronous
+        :meth:`generate_stream`.  Subclasses can override it with a truly
+        asynchronous variant.
+        """
+
+        for token in self.generate_stream(query, documents):
+            yield token


### PR DESCRIPTION
## Summary
- stream generator tokens asynchronously via background thread and queue
- add optional async streaming support for llama_index response generator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963074aca083298257b7256654324f