### PR TITLE
feat: add async streaming for generator

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -168,12 +168,71 @@ async def on_message(message: cl.Message) -> None:
                         score=0.2,
                     )
                 )
+        answer_parts: list[str] = []
         sent = cl.Message(content="")
         await sent.send()
-        answer_parts: list[str] = []
-        for token in generator.generate_stream(message.content, nodes):
-            answer_parts.append(token)
-            await sent.stream_token(token)
+
+        queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+        async def consume() -> None:
+            while True:
+                token = await queue.get()
+                if token is None:
+                    break
+                answer_parts.append(token)
+                await sent.stream_token(token)
+
+        consumer = asyncio.create_task(consume())
+        loop = asyncio.get_running_loop()
+
+        if hasattr(generator, "agenerate_stream"):
+
+            async def produce_async() -> None:
+                async for token in generator.agenerate_stream(message.content, nodes):
+                    await queue.put(token)
+                await queue.put(None)
+
+            producer = asyncio.create_task(produce_async())
+        else:
+
+            def produce_sync() -> None:
+                for token in generator.generate_stream(message.content, nodes):
+                    loop.call_soon_threadsafe(queue.put_nowait, token)
+                loop.call_soon_threadsafe(queue.put_nowait, None)
+
+            producer = asyncio.to_thread(produce_sync)
+
+        await asyncio.gather(producer, consumer)
+
+        answer = "".join(answer_parts)
+        sources = ", ".join(
+            sorted(
+                {
+                    (getattr(getattr(n, "node", n), "metadata", {}) or {}).get(
+                        "file_name"
+                    )
+                    or (getattr(getattr(n, "node", n), "metadata", {}) or {}).get(
+                        "source",
+                        "",
+                    )
+                    for n in nodes
+                    if getattr(getattr(n, "node", n), "metadata", None)
+                }
+            )
+        )
+
+        if sources:
+            sources_text = f"\n\nQuellen: {sources}"
+            answer += sources_text
+            await sent.stream_token(sources_text)
+
+        actions = [
+            cl.Action(name="copy", payload={"answer": answer}, label="Copy"),
+            cl.Action(name="retry", payload={}, label="Retry"),
+            cl.Action(name="vote", payload={"direction": "up"}, label="👍"),
+            cl.Action(name="vote", payload={"direction": "down"}, label="👎"),
+        ]
+        await sent.update(actions=actions)
     except Exception:
         logger.exception("Error during retrieval/generation")
         await cl.Message(
@@ -181,32 +240,6 @@ async def on_message(message: cl.Message) -> None:
         ).send()
         return
 
-    answer = "".join(answer_parts)
-    sources = ", ".join(
-        sorted(
-            {
-                (getattr(getattr(n, "node", n), "metadata", {}) or {}).get("file_name")
-                or (getattr(getattr(n, "node", n), "metadata", {}) or {}).get(
-                    "source", "",
-                )
-                for n in nodes
-                if getattr(getattr(n, "node", n), "metadata", None)
-            }
-        )
-    )
-
-    if sources:
-        sources_text = f"\n\nQuellen: {sources}"
-        answer += sources_text
-        await sent.stream_token(sources_text)
-
-    actions = [
-        cl.Action(name="copy", payload={"answer": answer}, label="Copy"),
-        cl.Action(name="retry", payload={}, label="Retry"),
-        cl.Action(name="vote", payload={"direction": "up"}, label="👍"),
-        cl.Action(name="vote", payload={"direction": "down"}, label="👎"),
-    ]
-    await sent.update(actions=actions)
 
 @cl.action_callback("retry")
 async def retry_callback(action: cl.Action) -> None:

--- a/backend/app.py
+++ b/backend/app.py
@@ -168,6 +168,7 @@ async def on_message(message: cl.Message) -> None:
                         score=0.2,
                     )
                 )
+
         answer_parts: list[str] = []
         actions = [
             cl.Action(name="copy", payload={"answer": ""}, label="Copy"),
@@ -218,8 +219,7 @@ async def on_message(message: cl.Message) -> None:
                         "file_name"
                     )
                     or (getattr(getattr(n, "node", n), "metadata", {}) or {}).get(
-                        "source",
-                        "",
+                        "source", ""
                     )
                     for n in nodes
                     if getattr(getattr(n, "node", n), "metadata", None)
@@ -228,7 +228,7 @@ async def on_message(message: cl.Message) -> None:
         )
 
         if sources:
-            sources_text = f"\n\nQuellen: {sources}"
+            sources_text = f"\\n\\nQuellen: {sources}"
             answer += sources_text
             await sent.stream_token(sources_text)
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -169,7 +169,13 @@ async def on_message(message: cl.Message) -> None:
                     )
                 )
         answer_parts: list[str] = []
-        sent = cl.Message(content="")
+        actions = [
+            cl.Action(name="copy", payload={"answer": ""}, label="Copy"),
+            cl.Action(name="retry", payload={}, label="Retry"),
+            cl.Action(name="vote", payload={"direction": "up"}, label="👍"),
+            cl.Action(name="vote", payload={"direction": "down"}, label="👎"),
+        ]
+        sent = cl.Message(content="", actions=actions)
         await sent.send()
 
         queue: asyncio.Queue[str | None] = asyncio.Queue()

--- a/backend/app.py
+++ b/backend/app.py
@@ -228,7 +228,7 @@ async def on_message(message: cl.Message) -> None:
         )
 
         if sources:
-            sources_text = f"\\n\\nQuellen: {sources}"
+            sources_text = f"\n\nQuellen: {sources}"
             answer += sources_text
             await sent.stream_token(sources_text)
 

--- a/core/adapters/llama_index/llama_index_adapter.py
+++ b/core/adapters/llama_index/llama_index_adapter.py
@@ -294,9 +294,7 @@ class LlamaIndexResponseGenerator(ResponseGenerator):
         response = self.synthesizer.synthesize(query, documents)
         return str(response)
 
-    def generate_stream(
-        self, query: str, documents: Sequence[Any]
-    ) -> Iterator[str]:
+    def generate_stream(self, query: str, documents: Sequence[Any]) -> Iterator[str]:
         """Yield tokens from the synthesized response as they are produced."""
 
         if self.thinking_steps > 1:

--- a/core/interfaces/response_generator.py
+++ b/core/interfaces/response_generator.py
@@ -1,7 +1,7 @@
 """Core interface for turning retrieved context into an answer."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Sequence
+from typing import Any, AsyncIterator, Iterator, Sequence
 
 
 class ResponseGenerator(ABC):
@@ -10,3 +10,27 @@ class ResponseGenerator(ABC):
     @abstractmethod
     def generate(self, query: str, documents: Sequence[Any]) -> str:
         """Return an answer to ``query`` based on ``documents``."""
+
+    def generate_stream(
+        self, query: str, documents: Sequence[Any]
+    ) -> Iterator[str]:
+        """Yield tokens for the answer.
+
+        The default implementation falls back to :meth:`generate`.
+        Implementations that support token streaming should override this.
+        """
+
+        yield self.generate(query, documents)
+
+    async def agenerate_stream(
+        self, query: str, documents: Sequence[Any]
+    ) -> AsyncIterator[str]:
+        """Asynchronously yield tokens for the answer.
+
+        This implementation simply iterates over the synchronous
+        :meth:`generate_stream`.  Subclasses can override it with a truly
+        asynchronous variant.
+        """
+
+        for token in self.generate_stream(query, documents):
+            yield token

--- a/core/interfaces/response_generator.py
+++ b/core/interfaces/response_generator.py
@@ -11,9 +11,7 @@ class ResponseGenerator(ABC):
     def generate(self, query: str, documents: Sequence[Any]) -> str:
         """Return an answer to ``query`` based on ``documents``."""
 
-    def generate_stream(
-        self, query: str, documents: Sequence[Any]
-    ) -> Iterator[str]:
+    def generate_stream(self, query: str, documents: Sequence[Any]) -> Iterator[str]:
         """Yield tokens for the answer.
 
         The default implementation falls back to :meth:`generate`.


### PR DESCRIPTION
## Summary
- stream generator tokens asynchronously via background thread and queue
- add optional async streaming support for llama_index response generator
- formalize streaming methods on the response generator interface

## Testing
- `pre-commit run --files backend/app.py`
- `PYENV_VERSION=3.11.12 pyenv exec python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963074aca083298257b7256654324f